### PR TITLE
refactor: junk characters in comment #nitpick

### DIFF
--- a/integration_tests/k8s/k8sapi.go
+++ b/integration_tests/k8s/k8sapi.go
@@ -174,7 +174,7 @@ func (c k8sClient) CreateServiceAccount(serviceAccount v1.ServiceAccount) error 
 	return err
 }
 
-// DeleteServiceAc[2050]:4589616count deletes the service account
+// DeleteServiceAccount deletes the service account
 func (c k8sClient) DeleteServiceAccount(serviceAccount v1.ServiceAccount) error {
 	err := c.RunTimeClient.Delete(context.Background(), &serviceAccount)
 	return err


### PR DESCRIPTION
correct the comment for the method DeleteServiceAccount()